### PR TITLE
Get CKAN version data from version file

### DIFF
--- a/RadioFreeKerbin.ckan
+++ b/RadioFreeKerbin.ckan
@@ -10,8 +10,7 @@
     "author"         : "benjwgarner",
     "description"    : "A mod for Kerbal Space Program that adds basic antenna capability to all stock or mod-provided crewed command parts.",
     "release_status" : "stable",
-    "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.3.9",
+    "$vref"          : "#/ckan/ksp-avc",
     
     
     "resources" : {
@@ -19,7 +18,7 @@
         "repository"   : "https://github.com/benjwgarner/RadioFreeKerbin",
         "bugtracker"   : "https://github.com/benjwgarner/RadioFreeKerbin/issues",
         "spacedock"    : "http://spacedock.info/mod/818/Radio%20Free%20Kerbin",
-		"x_screenshot" : "https://i.imgur.com/7WyuRZQ.png"
+        "x_screenshot" : "https://i.imgur.com/7WyuRZQ.png"
     },
     
     "install" : [


### PR DESCRIPTION
This mod contains a valid version file, which CKAN can use for compatibility info, but the metanetkan is currently not set up for this.

Now the version file will be used, which means one less place to edit when releasing.